### PR TITLE
Set packet TTL to 32 to allow router traversal

### DIFF
--- a/python/visionsocket.py
+++ b/python/visionsocket.py
@@ -53,6 +53,8 @@ def open_multicast_socket(ip, port):
     # Adapted from https://stackoverflow.com/a/1794373 (CC BY-SA 4.0 by Gordon Wrigley)
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
 
+    TTL = 32
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack('b', ttl))
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind((ip, port))
     sock.setsockopt(

--- a/src/udpsocket.cpp
+++ b/src/udpsocket.cpp
@@ -57,6 +57,11 @@ UDPSocket::UDPSocket(const std::string& ip, uint16_t port) {
 		std::cerr << "Setting SO_REUSEADDR on UDP socket failed" << std::endl;
 	}
 
+	int ttl = 32; 
+	if (setsockopt(socket_, IPPROTO_IP, IP_MULTICAST_TTL, (char*) &ttl, sizeof(ttl)) < 0) {
+			std::cerr << "Setting TTL failed" << std::endl;
+	}
+	
 	if(bind(socket_, &addr_, sizeof(addr_))) {
 		std::cerr << "Could not bind to multicast socket" << std::endl;
 	}


### PR DESCRIPTION
## Problem
Packets were failing to reach destinations on different network segments because the TTL was not explicitly set (default to 1).. They were expiring immediately upon hitting the gateway.

## Solution
Explicitly set the TTL setting to 32. This provides enough hops for the packets to survive routing through the network infrastructure.

## Verification
Confirmed that packets can now be received by hosts on separate subnets.