### PR TITLE
Fix NameError in open_multicast_socket due to case mismatch

### DIFF
--- a/python/visionsocket.py
+++ b/python/visionsocket.py
@@ -54,7 +54,7 @@ def open_multicast_socket(ip, port):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
 
     TTL = 32
-    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack('b', ttl))
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack('b', TTL))
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind((ip, port))
     sock.setsockopt(


### PR DESCRIPTION
The variable was defined as `TTL` (uppercase) but referenced as `ttl` (lowercase), which caused the program to crash. I have updated it to use the correct variable name.

It can be reproduced by running `python/geom_publisher.py geometry-divB.yml`.
After this fix, the TTL is correctly set to 32, ensuring that vision packets reach each team's AI without issues.

<img width="1020" height="416" alt="スクリーンショット 2026-02-20 133354" src="https://github.com/user-attachments/assets/84335eb3-dafa-4b55-a964-68f2337f1bbc" />
