### PR TITLE
 Auto-calibration diagnostics to json

### DIFF
--- a/src/calib/CalibDiagnostic.cpp
+++ b/src/calib/CalibDiagnostic.cpp
@@ -1,0 +1,80 @@
+/*
+     Copyright 2024 Felix Weinmann
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+ */
+#include "CalibDiagnostic.h"
+
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+static std::string jsonString(const std::string& s) {
+	std::string out;
+	out.reserve(s.size() + 2);
+	out.push_back('"');
+	for(char c : s) {
+		switch(c) {
+			case '"':  out += "\\\""; break;
+			case '\\': out += "\\\\"; break;
+			case '\n': out += "\\n";  break;
+			case '\r': out += "\\r";  break;
+			case '\t': out += "\\t";  break;
+			default:   out.push_back(c);
+		}
+	}
+	out.push_back('"');
+	return out;
+}
+
+void CalibDiagnostic::writeJson(const std::string& path) const {
+	std::ostringstream o;
+	o << std::setprecision(9);
+	o << "{\n";
+	o << "  \"camera_id\": " << camera_id << ",\n";
+	o << "  \"image_width\": " << image_width << ",\n";
+	o << "  \"image_height\": " << image_height << ",\n";
+
+	o << "  \"line_corners\": [";
+	for(size_t i = 0; i < line_corners.size(); i++) {
+		if(i) o << ", ";
+		o << "[" << line_corners[i].x() << ", " << line_corners[i].y() << "]";
+	}
+	o << "],\n";
+
+	o << "  \"camera_height\": " << camera_height << ",\n";
+	o << "  \"refinement_enabled\": " << (refinement_enabled ? "true" : "false") << ",\n";
+
+	o << "  \"half_line_width\": " << half_line_width << ",\n";
+	o << "  \"line_pixel_count\": " << line_pixel_count << ",\n";
+	o << "  \"raw_line_segments\": " << raw_line_segments << ",\n";
+	o << "  \"merged_line_count\": " << merged_line_count << ",\n";
+
+	o << "  \"focal_length\": " << focal_length << ",\n";
+	o << "  \"position\": [" << position.x() << ", " << position.y() << ", " << position.z() << "],\n";
+	o << "  \"euler\": [" << euler.x() << ", " << euler.y() << ", " << euler.z() << "],\n";
+	o << "  \"distortion_k2\": " << distortion_k2 << ",\n";
+	o << "  \"principal_point\": [" << principal_point.x() << ", " << principal_point.y() << "],\n";
+
+	o << "  \"total_error\": " << total_error << ",\n";
+	o << "  \"error_rate\": " << error_rate << ",\n";
+
+	o << "  \"thresholded_image_path\": " << jsonString(thresholded_image_path) << ",\n";
+	o << "  \"lines_image_path\": " << jsonString(lines_image_path) << ",\n";
+	o << "  \"corner_overlay_path\": " << jsonString(corner_overlay_path) << ",\n";
+	o << "  \"refined_overlay_path\": " << jsonString(refined_overlay_path) << "\n";
+	o << "}\n";
+
+	std::ofstream f(path);
+	f << o.str();
+}

--- a/src/calib/CalibDiagnostic.h
+++ b/src/calib/CalibDiagnostic.h
@@ -1,0 +1,50 @@
+/*
+     Copyright 2024 Felix Weinmann
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+struct CalibDiagnostic {
+	int camera_id = -1;
+	int image_width = 0;
+	int image_height = 0;
+	std::vector<Eigen::Vector2f> line_corners;
+	double camera_height = 0.0;
+	bool refinement_enabled = false;
+
+	int half_line_width = 0;
+	int line_pixel_count = 0;
+	int raw_line_segments = 0;
+	int merged_line_count = 0;
+
+	float focal_length = 0.0f;
+	Eigen::Vector3f position = Eigen::Vector3f::Zero();
+	Eigen::Vector3f euler = Eigen::Vector3f::Zero();
+	float distortion_k2 = 0.0f;
+	Eigen::Vector2f principal_point = Eigen::Vector2f::Zero();
+
+	int total_error = 0;
+	float error_rate = 0.0f;
+
+	std::string thresholded_image_path;
+	std::string lines_image_path;
+	std::string corner_overlay_path;
+	std::string refined_overlay_path;
+
+	void writeJson(const std::string& path) const;
+};

--- a/src/calib/GeomModel.cpp
+++ b/src/calib/GeomModel.cpp
@@ -15,6 +15,7 @@
  */
 #include <opencv2/opencv.hpp>
 #include "GeomModel.h"
+#include "CalibDiagnostic.h"
 #include "Distortion.h"
 #include "LineDetection.h"
 #include "proto/ssl_vision_wrapper.pb.h"
@@ -503,12 +504,25 @@ static bool cornerCalibration(const Resources& r, const std::vector<std::vector<
 void geometryCalibration(const Resources& r, const CLImage& rgba) {
 	rgba.save(".geomcalib_input.png");
 
+	CalibDiagnostic diag;
+	diag.camera_id = r.camId;
+	diag.image_width = rgba.width;
+	diag.image_height = rgba.height;
+	diag.line_corners = r.lineCorners;
+	diag.camera_height = r.cameraHeight;
+	diag.refinement_enabled = r.geometryRefinement;
+	diag.thresholded_image_path = "img/" + rgba.name + ".pixels.png";
+	diag.lines_image_path = "img/" + rgba.name + ".lines.png";
+	diag.corner_overlay_path = "img/" + rgba.name + ".pixels.corner.png";
+	diag.refined_overlay_path = "img/" + rgba.name + ".pixels.refined.png";
+
 	cv::Mat bgr;
 	cv::cvtColor(rgba.read<RGBA>().cv, bgr, cv::COLOR_RGBA2BGR);
 	cv::Mat gray;
 	cv::cvtColor(rgba.read<RGBA>().cv, gray, cv::COLOR_RGBA2GRAY);
 
 	const int halfLineWidth = halfLineWidthEstimation(r, gray);
+	diag.half_line_width = halfLineWidth;
 	std::cout << "[Geometry calibration] Half line width: " << halfLineWidth << std::endl;
 
 	cv::Mat thresholded(gray.rows, gray.cols, CV_8UC1, 0.0);
@@ -516,6 +530,7 @@ void geometryCalibration(const Resources& r, const CLImage& rgba) {
 	cv::imwrite("img/" + rgba.name + ".pixels.png", thresholded);
 
 	const std::vector<Eigen::Vector2f> linePixels = getLinePixels(thresholded);
+	diag.line_pixel_count = (int)linePixels.size();
 
 	cv::Ptr<cv::LineSegmentDetector> detector = cv::createLineSegmentDetector();
 	cv::Mat4f linesMat;
@@ -530,10 +545,12 @@ void geometryCalibration(const Resources& r, const CLImage& rgba) {
 		if(dist(a, b) >= r.minLineSegmentLength)
 			lines.emplace_back(a, b);
 	}
+	diag.raw_line_segments = (int)lines.size();
 	std::cout << "[Geometry calibration] Line segments: " << lines.size() << std::endl;
 
 	const std::vector<CVLines> compoundLines = groupLineSegments(r, lines);
 	const CVLines mergedLines = mergeLineSegments(compoundLines);
+	diag.merged_line_count = (int)mergedLines.size();
 	std::cout << "[Geometry calibration] Lines: " << mergedLines.size() << std::endl;
 
 	std::vector<std::vector<Eigen::Vector2f>> mergedPixels(mergedLines.size());
@@ -579,6 +596,14 @@ void geometryCalibration(const Resources& r, const CLImage& rgba) {
 	int error = modelError(r, model, linePixels);
 	std::cout << "[Geometry calibration] Best model: " << model << " error " << (error/(float)linePixels.size()) << std::endl;
 
+	diag.focal_length = model.focalLength;
+	diag.position = model.pos;
+	diag.euler = model.getEuler();
+	diag.distortion_k2 = model.distortionK2;
+	diag.principal_point = model.principalPoint;
+	diag.total_error = error;
+	diag.error_rate = linePixels.empty() ? 0.0f : (float)error / (float)linePixels.size();
+
 	SSL_WrapperPacket wrapper;
 	wrapper.set_source(SSL_SOURCE_VISION_PROCESSOR);
 	wrapper.mutable_geometry()->CopyFrom(r.socket->getGeometry());
@@ -588,4 +613,6 @@ void geometryCalibration(const Resources& r, const CLImage& rgba) {
 
 	drawModel(r, thresholded, linePixels, model);
 	cv::imwrite("img/" + rgba.name + ".pixels.refined.png", thresholded);
+
+	diag.writeJson("img/" + rgba.name + ".calib.json");
 }


### PR DESCRIPTION
Writes a JSON snapshot of each auto-calibration run to img/<name>.calib.json so external tools can see the result without scraping stdout.

Contains: camera id, image size, configured line corners, line detection counts, final camera model (focal length, position, euler, distortion, principal point), error count and rate, and paths to the existing PNG artifacts.

Overwritten on every call. Once the calibration is accepted, geometryCalibration stops being called, so the file stays as the accepted result.
