### PR TITLE
Add debug image stream during calibration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -148,3 +148,5 @@ debug:
   #wait_for_geometry: false
   # Save additional debug images in img/.
   #debug_images: false
+  # Periodically overwrite img/.sample.<camId>.png while calibration isn't accepted yet, every N milliseconds. 0 disables.
+  #debug_stream_interval_ms: 0

--- a/src/Resources.cpp
+++ b/src/Resources.cpp
@@ -120,6 +120,7 @@ Resources::Resources(const YAML::Node& config) {
 	groundTruth = debug["ground_truth"].as<std::string>("gt.yml");
 	bool waitForGeometry = debug["wait_for_geometry"].as<bool>(false);
 	debugImages = debug["debug_images"].as<bool>(false);
+	debugStreamInterval = debug["debug_stream_interval"].as<int>(0);
 
 	YAML::Node network = getOptional(config["network"]);
 	gcSocket = std::make_shared<GCSocket>(network["gc_ip"].as<std::string>("224.5.23.1"), network["gc_port"].as<int>(10003), YAML::LoadFile(config["bot_heights_file"].as<std::string>("robot-heights.yml")).as<std::map<std::string, double>>());

--- a/src/Resources.cpp
+++ b/src/Resources.cpp
@@ -120,7 +120,7 @@ Resources::Resources(const YAML::Node& config) {
 	groundTruth = debug["ground_truth"].as<std::string>("gt.yml");
 	bool waitForGeometry = debug["wait_for_geometry"].as<bool>(false);
 	debugImages = debug["debug_images"].as<bool>(false);
-	debugStreamInterval = debug["debug_stream_interval"].as<int>(0);
+	debugStreamIntervalMs = debug["debug_stream_interval_ms"].as<int>(0);
 
 	YAML::Node network = getOptional(config["network"]);
 	gcSocket = std::make_shared<GCSocket>(network["gc_ip"].as<std::string>("224.5.23.1"), network["gc_port"].as<int>(10003), YAML::LoadFile(config["bot_heights_file"].as<std::string>("robot-heights.yml")).as<std::map<std::string, double>>());

--- a/src/Resources.h
+++ b/src/Resources.h
@@ -82,6 +82,7 @@ public:
 
 	std::string groundTruth;
 	bool debugImages;
+	int debugStreamInterval;
 	bool rawFeed;
 
 	std::shared_ptr<GCSocket> gcSocket;

--- a/src/Resources.h
+++ b/src/Resources.h
@@ -82,7 +82,7 @@ public:
 
 	std::string groundTruth;
 	bool debugImages;
-	int debugStreamInterval;
+	int debugStreamIntervalMs;
 	bool rawFeed;
 
 	std::shared_ptr<GCSocket> gcSocket;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,6 +253,7 @@ int main(int argc, char* argv[]) {
 	cl::Kernel blobList = r.openCl->compile(kernel_blobList_cl);
 
 	uint32_t frameId = 0;
+	double lastDebugSaveTime = 0.0;
 	CLArray matchArray(sizeof(CLMatch) * r.maxBlobs);
 	CLArray counter(sizeof(cl_int)*3);
 
@@ -393,18 +394,20 @@ int main(int argc, char* argv[]) {
 		} else if(r.socket->getGeometryVersion()) {
 			geometryCalibration(r, *r.quad2rgba(channels));
 
-			if(r.debugStreamInterval > 0 && frameId % r.debugStreamInterval == 0)
-				r.quad2rgba(channels)->save(".debug." + std::to_string(r.camId) + ".jpg");
+			if(r.debugStreamIntervalMs > 0 && (realStartTime - lastDebugSaveTime) * 1000.0 >= r.debugStreamIntervalMs) {
+				r.quad2rgba(channels)->save(".sample." + std::to_string(r.camId) + ".png");
+				lastDebugSaveTime = realStartTime;
+			}
 		} else {
 			r.streamQuad(channels);
 
-			if(frameId == 100) {  // Wait for automatic gain, exposure and white balance adjustments
+			bool periodicSave = r.debugStreamIntervalMs > 0 && (realStartTime - lastDebugSaveTime) * 1000.0 >= r.debugStreamIntervalMs;
+			if(frameId == 100 || periodicSave) {  // Wait for automatic gain, exposure and white balance adjustments
 				r.quad2rgba(channels)->save(".sample." + std::to_string(r.camId) + ".png");
-				std::cout << "[main] Saved sample image" << std::endl;
+				lastDebugSaveTime = realStartTime;
+				if(frameId == 100)
+					std::cout << "[main] Saved sample image" << std::endl;
 			}
-
-			if(r.debugStreamInterval > 0 && frameId % r.debugStreamInterval == 0)
-				r.quad2rgba(channels)->save(".debug." + std::to_string(r.camId) + ".jpg");
 		}
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -392,6 +392,9 @@ int main(int argc, char* argv[]) {
 			}
 		} else if(r.socket->getGeometryVersion()) {
 			geometryCalibration(r, *r.quad2rgba(channels));
+
+			if(r.debugStreamInterval > 0 && frameId % r.debugStreamInterval == 0)
+				r.quad2rgba(channels)->save(".debug." + std::to_string(r.camId) + ".jpg");
 		} else {
 			r.streamQuad(channels);
 
@@ -399,6 +402,9 @@ int main(int argc, char* argv[]) {
 				r.quad2rgba(channels)->save(".sample." + std::to_string(r.camId) + ".png");
 				std::cout << "[main] Saved sample image" << std::endl;
 			}
+
+			if(r.debugStreamInterval > 0 && frameId % r.debugStreamInterval == 0)
+				r.quad2rgba(channels)->save(".debug." + std::to_string(r.camId) + ".jpg");
 		}
 	}
 


### PR DESCRIPTION
Writes a JPEG of the current camera view every N frames while the calibration isn't locked in yet. Useful for previewing what the  camera sees while tuning line corners or other settings, without  needing to restart and check the cold-start sample.   

 Controlled by `debug.debug_stream_interval` in config.yml. Default  is 0 (off). Once the calibration is accepted, the stream stops, so  nothing extra runs during normal operation. 