### PR TITLE
Add hot reload for runtime-tunable config fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ Installation with PIP: `pip install protobuf pyyaml`
 5. Restart the `vision_processor`s for the generation of a new sample image `img/sample.[X].png`
    and complete the `geometry` section of each camera config with it.
    Visual explanation how to determine `line_corners`: ![Line corner example](line_corners.png)
-6. Restart all `vision_processor`s to reload the config.
+6. Restart all `vision_processor`s to pick up the new `geometry` section.
+   Subsequent edits to thresholds, tracking limits and color references in `config[X].yml`
+   are picked up live (within ~0.5 s) without a restart; camera, geometry, network and stream
+   sections still require a restart.
 7. Modify `geometry[X].yml` to match your field geometry.
    (for simple use cases configuring the field size, penalty area and goal will suffice)
 8. Start `python/geom_publisher.py geometry[X].yml`.

--- a/src/Resources.cpp
+++ b/src/Resources.cpp
@@ -213,6 +213,11 @@ void Resources::applyTunables(const YAML::Node& config) {
 }
 
 void Resources::reloadConfigIfChanged() {
+	double now = getRealTime();
+	if(now - lastConfigCheckTime < 0.5)
+		return;
+	lastConfigCheckTime = now;
+
 	struct stat st{};
 	if(stat(configPath.c_str(), &st) != 0)
 		return;

--- a/src/Resources.cpp
+++ b/src/Resources.cpp
@@ -14,6 +14,8 @@
      limitations under the License.
  */
 #include <yaml-cpp/yaml.h>
+#include <sys/stat.h>
+#include <iostream>
 
 #include "cl_kernels.h"
 #include "Resources.h"
@@ -65,7 +67,12 @@ static YAML::Node getOptional(const YAML::Node& node) {
 	return node.IsDefined() ? node : YAML::Node();
 }
 
-Resources::Resources(const YAML::Node& config) {
+Resources::Resources(const std::string& configPath) : configPath(configPath) {
+	YAML::Node config = YAML::LoadFile(configPath);
+	struct stat st{};
+	if(stat(configPath.c_str(), &st) == 0)
+		configMtime = (int64_t)st.st_mtim.tv_sec * 1000000000 + st.st_mtim.tv_nsec;
+
 	openCl = std::make_shared<OpenCL>();
 	camera = openCamera(CameraConfig(getOptional(config["camera"])));
 
@@ -75,19 +82,18 @@ Resources::Resources(const YAML::Node& config) {
 		exit(1);
 	}
 
-	YAML::Node thresholds = getOptional(config["thresholds"]);
-	minCircularity = thresholds["circularity"].as<double>(15.0);
-	minScore = thresholds["score"].as<double>(5.0);
-	maxBlobs = thresholds["blobs"].as<int>(2000);
-	minConfidence = thresholds["min_confidence"].as<float>(0.2f);
-	minCamEdgeDistance = thresholds["min_cam_edge_distance"].as<double>(170.0);
-	resamplingFactor = thresholds["resampling_factor"].as<float>(1.0f);
-	clippingTolerance = thresholds["clipping_tolerance"].as<float>(10.0f);
-	geometryTolerance = thresholds["geometry_tolerance"].as<float>(10.0f);
+	maxBlobs = getOptional(config["thresholds"])["blobs"].as<int>(2000);
+	geometryTolerance = getOptional(config["thresholds"])["geometry_tolerance"].as<float>(10.0f);
 
-	YAML::Node tracking = getOptional(config["tracking"]);
-	minTrackingRadius = tracking["min_tracking_radius"].as<double>(20.0);
-	maxBotAcceleration = 1000 * tracking["max_bot_acceleration"].as<double>(6.5);
+	applyTunables(config);
+
+	orange = orangeReference;
+	field = fieldReference;
+	yellow = yellowReference;
+	blue = blueReference;
+	green = greenReference;
+	pink = pinkReference;
+	fieldLineColor = fieldReference;
 
 	YAML::Node geometry = getOptional(config["geometry"]);
 	cameraAmount = geometry["camera_amount"].as<int>(1);
@@ -99,27 +105,9 @@ Resources::Resources(const YAML::Node& config) {
 	maxLineSegmentOffset = geometry["max_line_segment_offset"].as<double>(10.0);
 	maxLineSegmentAngle = geometry["max_line_segment_angle"].as<double>(3.0) * M_PI/180.0;
 
-	YAML::Node color = getOptional(config["color"]);
-	referenceForce = color["reference_force"].as<float>(0.1f);
-	historyForce = color["history_force"].as<float>(0.7f);
-	orangeReference = color["orange"].as<Eigen::Vector3i>(Eigen::Vector3i{192, 128, 64});
-	fieldReference = color["field"].as<Eigen::Vector3i>(Eigen::Vector3i{128, 128, 128});
-	yellowReference = color["yellow"].as<Eigen::Vector3i>(Eigen::Vector3i{255, 128, 0});
-	blueReference = color["blue"].as<Eigen::Vector3i>(Eigen::Vector3i{0, 128, 255});
-	greenReference = color["green"].as<Eigen::Vector3i>(Eigen::Vector3i{0, 255, 128});
-	pinkReference = color["pink"].as<Eigen::Vector3i>(Eigen::Vector3i{255, 0, 128});
-	orange = orangeReference;
-	field = fieldReference;
-	yellow = yellowReference;
-	blue = blueReference;
-	green = greenReference;
-	pink = pinkReference;
-	fieldLineColor = fieldReference;
-
 	YAML::Node debug = getOptional(config["debug"]);
 	groundTruth = debug["ground_truth"].as<std::string>("gt.yml");
 	bool waitForGeometry = debug["wait_for_geometry"].as<bool>(false);
-	debugImages = debug["debug_images"].as<bool>(false);
 
 	YAML::Node network = getOptional(config["network"]);
 	gcSocket = std::make_shared<GCSocket>(network["gc_ip"].as<std::string>("224.5.23.1"), network["gc_port"].as<int>(10003), YAML::LoadFile(config["bot_heights_file"].as<std::string>("robot-heights.yml")).as<std::map<std::string, double>>());
@@ -195,4 +183,49 @@ void Resources::streamImage(CLImage &img) {
 	std::shared_ptr<RawImage> nv12 = openCl->acquireNV12(img.width, img.height);
 	openCl->await(kernel, cl::EnqueueArgs(cl::NDRange(img.width, img.height)), img.image, nv12->buffer);
 	rtpStreamer->sendFrame(nv12);
+}
+
+void Resources::applyTunables(const YAML::Node& config) {
+	YAML::Node thresholds = getOptional(config["thresholds"]);
+	minCircularity = thresholds["circularity"].as<double>(15.0);
+	minScore = thresholds["score"].as<double>(5.0);
+	minConfidence = thresholds["min_confidence"].as<float>(0.2f);
+	minCamEdgeDistance = thresholds["min_cam_edge_distance"].as<double>(170.0);
+	resamplingFactor = thresholds["resampling_factor"].as<float>(1.0f);
+	clippingTolerance = thresholds["clipping_tolerance"].as<float>(10.0f);
+
+	YAML::Node tracking = getOptional(config["tracking"]);
+	minTrackingRadius = tracking["min_tracking_radius"].as<double>(20.0);
+	maxBotAcceleration = 1000 * tracking["max_bot_acceleration"].as<double>(6.5);
+
+	YAML::Node color = getOptional(config["color"]);
+	referenceForce = color["reference_force"].as<float>(0.1f);
+	historyForce = color["history_force"].as<float>(0.7f);
+	orangeReference = color["orange"].as<Eigen::Vector3i>(Eigen::Vector3i{192, 128, 64});
+	fieldReference = color["field"].as<Eigen::Vector3i>(Eigen::Vector3i{128, 128, 128});
+	yellowReference = color["yellow"].as<Eigen::Vector3i>(Eigen::Vector3i{255, 128, 0});
+	blueReference = color["blue"].as<Eigen::Vector3i>(Eigen::Vector3i{0, 128, 255});
+	greenReference = color["green"].as<Eigen::Vector3i>(Eigen::Vector3i{0, 255, 128});
+	pinkReference = color["pink"].as<Eigen::Vector3i>(Eigen::Vector3i{255, 0, 128});
+
+	YAML::Node debug = getOptional(config["debug"]);
+	debugImages = debug["debug_images"].as<bool>(false);
+}
+
+void Resources::reloadConfigIfChanged() {
+	struct stat st{};
+	if(stat(configPath.c_str(), &st) != 0)
+		return;
+	int64_t mtime = (int64_t)st.st_mtim.tv_sec * 1000000000 + st.st_mtim.tv_nsec;
+	if(mtime == configMtime)
+		return;
+	configMtime = mtime;
+
+	try {
+		YAML::Node config = YAML::LoadFile(configPath);
+		applyTunables(config);
+		std::cout << "[Resources] Reloaded tunables from " << configPath << std::endl;
+	} catch(const YAML::Exception& e) {
+		std::cerr << "[Resources] Config reload failed, keeping previous values: " << e.what() << std::endl;
+	}
 }

--- a/src/Resources.h
+++ b/src/Resources.h
@@ -37,7 +37,9 @@ typedef struct __attribute__ ((packed)) RGB {
 
 class Resources {
 public:
-	explicit Resources(const YAML::Node& config);
+	explicit Resources(const std::string& configPath);
+
+	void reloadConfigIfChanged();
 
 	std::unique_ptr<CameraDriver> camera = nullptr;
 
@@ -107,4 +109,9 @@ public:
 
 	void streamQuad(std::shared_ptr<CLImage>* channels);
 	void streamImage(CLImage& img);
+
+private:
+	std::string configPath;
+	int64_t configMtime = 0;
+	void applyTunables(const YAML::Node& config);
 };

--- a/src/Resources.h
+++ b/src/Resources.h
@@ -113,5 +113,6 @@ public:
 private:
 	std::string configPath;
 	int64_t configMtime = 0;
+	double lastConfigCheckTime = 0.0;
 	void applyTunables(const YAML::Node& config);
 };

--- a/src/blob_benchmark.cpp
+++ b/src/blob_benchmark.cpp
@@ -112,8 +112,7 @@ static void scoreBot(const Resources& r, const CLImageMap<float>& circMap, const
 
 
 int main(int argc, char* argv[]) {
-	YAML::Node configFile = YAML::LoadFile(argc > 1 ? argv[1] : "config.yml");
-	Resources r(configFile);
+	Resources r(argc > 1 ? argv[1] : "config.yml");
 	std::vector<SSL_DetectionFrame> groundTruth = parseGroundTruth(r.groundTruth);
 	cl::Kernel scoreKernel = r.openCl->compile(kernel_blobScore_cl);
 

--- a/src/geometry_benchmark.cpp
+++ b/src/geometry_benchmark.cpp
@@ -52,7 +52,7 @@ static void geometryBenchmark(Resources& r, const uint32_t frameId) {
 }
 
 int main(int argc, char* argv[]) {
-	Resources r(YAML::LoadFile(argc > 1 ? argv[1] : "config.yml"));
+	Resources r(argc > 1 ? argv[1] : "config.yml");
 
 	std::shared_ptr<RawImage> img = r.camera->readImage();
 	r.perspective->geometryCheck(img->width, img->height, r.gcSocket->maxBotHeight, r.resamplingFactor);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,7 +249,7 @@ void sig_stop(int sig_num) {
 }
 
 int main(int argc, char* argv[]) {
-	Resources r(YAML::LoadFile(argc > 1 ? argv[1] : "config.yml"));
+	Resources r(argc > 1 ? argv[1] : "config.yml");
 	cl::Kernel blobList = r.openCl->compile(kernel_blobList_cl);
 
 	uint32_t frameId = 0;
@@ -260,6 +260,7 @@ int main(int argc, char* argv[]) {
 	signal(SIGINT, sig_stop);
 	while(noSigterm) {
 		frameId++;
+		r.reloadConfigIfChanged();
 		std::shared_ptr<RawImage> img = r.camera->readImage();
 		if(img == nullptr)
 			break;


### PR DESCRIPTION
Restarting the whole pipeline every time you want to nudge a threshold or a color is annoying. With this change, you can edit the config file while everything is running and it picks up the new values on the  next frame. If you save a typo, it just logs the error and keeps using the old values until you fix it.

Only the safe-to-change fields hot reload: thresholds, tracking limits, colors and the debug image flag. Anything that's wired into the camera, the geometry, the network or the GPU kernels still needs a restart, since swapping those out live would either need driver-specific work or quietly break things. Camera settings could be a follow-up.

Tested locally against an RTSP camera: edits get picked up, broken YAML is ignored, and even rapid  back-to-back saves all register.