### PR TITLE
WebSocket bridge from the wrapper bus to browser clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.12"
 dependencies = [
     "protobuf>=7.34.1",
     "pyyaml>=6.0.3",
+    "websockets>=16.0",
 ]
 
 [dependency-groups]

--- a/python/ws_tail.py
+++ b/python/ws_tail.py
@@ -1,6 +1,6 @@
 """Tail a wrapper websocket channel. Usage:
 
-uv run python tools/ws_tail.py [--url ws://127.0.0.1:8765] [--topic wrapper_packet.out]
+uv run python python/ws_tail.py [--url ws://127.0.0.1:8765] [--topic wrapper_packet.out]
 """
 
 from __future__ import annotations

--- a/tools/ws_tail.py
+++ b/tools/ws_tail.py
@@ -1,0 +1,29 @@
+"""Tail a wrapper websocket channel. Usage:
+
+uv run python tools/ws_tail.py [--url ws://127.0.0.1:8765] [--topic wrapper_packet.out]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from websockets.asyncio.client import connect
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="ws://127.0.0.1:8765")
+    parser.add_argument("--topic", default="wrapper_packet.out")
+    args = parser.parse_args()
+
+    async with connect(args.url) as ws:
+        await ws.send(json.dumps({"action": "subscribe", "topic": args.topic}))
+        async for raw in ws:
+            frame = json.loads(raw)
+            print(json.dumps(frame, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/uv.lock
+++ b/uv.lock
@@ -384,6 +384,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "protobuf" },
     { name = "pyyaml" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -399,6 +400,7 @@ dev = [
 requires-dist = [
     { name = "protobuf", specifier = ">=7.34.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "websockets", specifier = ">=16.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -408,4 +410,49 @@ dev = [
     { name = "ruff", specifier = ">=0.15.12" },
     { name = "types-protobuf", specifier = ">=7.34.1.20260503" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260408" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]

--- a/wrapper/CLAUDE.md
+++ b/wrapper/CLAUDE.md
@@ -14,11 +14,12 @@ All run from repo root.
 
 ## Architecture
 
-Three modules glued by a watch-channel pub/sub bus:
+Four modules glued by a watch-channel pub/sub bus:
 
 - `bus.py` — every `subscribe(topic)` returns its own size-1 `asyncio.Queue`. `publish` drains-then-puts; slow subscribers see only the latest value.
 - `multicast.py` — `asyncio.DatagramProtocol` UDP. Inbound parses `SSL_WrapperPacket` and demuxes into `geometry.in` / `detection.in`. Outbound subscribes to `wrapper_packet.out` (bytes) and `sendto`s.
 - `geometry.py` — owns `geometry.yml` + in-memory `SSL_WrapperPacket`. Two tasks: `_absorb_loop` (replace-or-append calibs) and `_publish_loop` (1 Hz emit). Both share `self._wrapper`; no locks because asyncio doesn't preempt between non-`await` statements. Publisher serialises to bytes before publishing so the snapshot is locked-in before the multicast adapter awaits.
+- `websocket.py` — `websockets`-based JSON bridge. Lazy per-topic bus subscription: a channel's bus-reader task starts when the first client joins and stops when the last leaves. Each connected client owns its own size-1 outbound queue (slow clients drop intermediate frames). Read-only for now; envelope (`{"topic": ..., "data": ...}` and `{"action": ..., "topic": ...}`) is symmetric so inbound commands can be added later without breaking the wire format. Topic-to-JSON encoders live in `_TOPIC_ENCODERS`.
 
 Topics: `geometry.in`, `detection.in` (inbound demuxed), `wrapper_packet.out` (outbound bytes).
 
@@ -33,8 +34,8 @@ Topics: `geometry.in`, `detection.in` (inbound demuxed), `wrapper_packet.out` (o
 
 ## CLI flags
 
-Dash form only: `--vision-ip`, `--vision-port`. `geom_publisher.py`'s underscore form is dropped.
+Dash form only: `--vision-ip`, `--vision-port`, `--ws-host`, `--ws-port`. `geom_publisher.py`'s underscore form is dropped.
 
 ## Out-of-scope (planned but not yet built)
 
-Web UI, WebSocket bridge, `vision_processor` subprocess supervisor, calib persistence to `geometry.yml`. Each will be an additive module subscribing to the bus — don't restructure existing modules to anticipate them.
+Web UI, `vision_processor` subprocess supervisor, calib persistence to `geometry.yml`. Each will be an additive module subscribing to the bus — don't restructure existing modules to anticipate them.

--- a/wrapper/__main__.py
+++ b/wrapper/__main__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from wrapper.bus import Bus
 from wrapper.geometry import Geometry
 from wrapper.multicast import Multicast
+from wrapper.websocket import WebSocketServer
 
 
 async def _main() -> None:
@@ -22,16 +23,21 @@ async def _main() -> None:
     parser.add_argument("geometry", type=Path, help="geometry.yml path")
     parser.add_argument("--vision-ip", default="224.5.23.2")
     parser.add_argument("--vision-port", type=int, default=10006)
+    parser.add_argument("--ws-host", default="0.0.0.0")
+    parser.add_argument("--ws-port", type=int, default=8765)
     args = parser.parse_args()
 
     bus = Bus()
     multicast = Multicast(bus, args.vision_ip, args.vision_port)
     geometry = Geometry(bus, args.geometry)
+    websocket = WebSocketServer(bus, args.ws_host, args.ws_port)
 
-    await multicast.start()
     try:
+        await multicast.start()
+        await websocket.start()
         await geometry.run()
     finally:
+        await websocket.close()
         await multicast.close()
 
 

--- a/wrapper/websocket.py
+++ b/wrapper/websocket.py
@@ -1,0 +1,182 @@
+"""WebSocket bridge from the bus to browser clients.
+
+Each connected client owns a size-1 outbound queue (slow clients drop
+intermediate frames, matching the bus's watch-channel semantics).
+
+A "channel" represents one bus topic. The bus is read lazily: when the
+first client joins a channel its bus-reader task starts; when the last
+client leaves it stops. Topics nobody is listening to cost nothing.
+
+Wire protocol (JSON, both directions):
+
+    client -> server   {"action": "subscribe",   "topic": "..."}
+    client -> server   {"action": "unsubscribe", "topic": "..."}
+    server -> client   {"topic": "...", "data": {...}}
+    server -> client   {"error": "...", "topic": "..."}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Callable
+
+from google.protobuf.json_format import MessageToDict
+from websockets.asyncio.server import Server, ServerConnection, serve
+from websockets.exceptions import ConnectionClosed
+
+from proto.ssl_vision_wrapper_pb2 import SSL_WrapperPacket
+from wrapper.bus import Bus
+
+log = logging.getLogger("wrapper.websocket")
+
+
+def _encode_wrapper_packet(payload: bytes) -> dict[str, Any]:
+    packet = SSL_WrapperPacket()
+    packet.ParseFromString(payload)
+    return MessageToDict(packet, preserving_proto_field_name=True)
+
+
+# Encoders convert the raw bus payload for a topic into a JSON-serialisable
+# dict. Topics not present here cannot be exposed to clients.
+_TOPIC_ENCODERS: dict[str, Callable[[Any], dict[str, Any]]] = {
+    "wrapper_packet.out": _encode_wrapper_packet,
+}
+
+
+class _Client:
+    def __init__(self, connection: ServerConnection) -> None:
+        self._connection = connection
+        self._outbox: asyncio.Queue[str] = asyncio.Queue(maxsize=1)
+        self.topics: set[str] = set()
+
+    def post(self, frame: str) -> None:
+        try:
+            self._outbox.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+        self._outbox.put_nowait(frame)
+
+    async def send_error(self, message: str, topic: str | None = None) -> None:
+        payload: dict[str, str] = {"error": message}
+        if topic is not None:
+            payload["topic"] = topic
+        await self._connection.send(json.dumps(payload))
+
+    async def deliver_forever(self) -> None:
+        while True:
+            frame = await self._outbox.get()
+            try:
+                await self._connection.send(frame)
+            except ConnectionClosed:
+                return
+
+
+class _Channel:
+    def __init__(self, task: asyncio.Task[None]) -> None:
+        self.clients: set[_Client] = set()
+        self.task = task
+
+
+class WebSocketServer:
+    def __init__(self, bus: Bus, host: str, port: int) -> None:
+        self._bus = bus
+        self._host = host
+        self._port = port
+        self._channels: dict[str, _Channel] = {}
+        self._server: Server | None = None
+
+    async def start(self) -> None:
+        self._server = await serve(self._handle_client, self._host, self._port)
+        log.info("websocket listening on %s:%d", self._host, self._port)
+
+    async def close(self) -> None:
+        for topic, channel in list(self._channels.items()):
+            channel.task.cancel()
+            try:
+                await channel.task
+            except asyncio.CancelledError:
+                pass
+            self._channels.pop(topic, None)
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle_client(self, connection: ServerConnection) -> None:
+        client = _Client(connection)
+        peer = connection.remote_address
+        log.info("client connected: %s", peer)
+        delivery = asyncio.create_task(client.deliver_forever(), name="ws-deliver")
+        try:
+            async for raw in connection:
+                await self._on_client_message(client, raw)
+        except ConnectionClosed:
+            pass
+        finally:
+            for topic in list(client.topics):
+                self._leave(client, topic)
+            delivery.cancel()
+            try:
+                await delivery
+            except asyncio.CancelledError:
+                pass
+            log.info("client disconnected: %s", peer)
+
+    async def _on_client_message(self, client: _Client, raw: str | bytes) -> None:
+        try:
+            request = json.loads(raw)
+            action = request["action"]
+            topic = request["topic"]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            await client.send_error("malformed request")
+            return
+
+        if action == "subscribe":
+            if topic not in _TOPIC_ENCODERS:
+                await client.send_error("unknown topic", topic)
+                return
+            self._join(client, topic)
+        elif action == "unsubscribe":
+            self._leave(client, topic)
+        else:
+            await client.send_error("unknown action", topic)
+
+    def _join(self, client: _Client, topic: str) -> None:
+        channel = self._channels.get(topic)
+        if channel is None:
+            task = asyncio.create_task(
+                self._forward_topic(topic), name=f"ws-forward-{topic}"
+            )
+            channel = self._channels[topic] = _Channel(task)
+            log.info("opened channel %s", topic)
+        channel.clients.add(client)
+        client.topics.add(topic)
+
+    def _leave(self, client: _Client, topic: str) -> None:
+        channel = self._channels.get(topic)
+        if channel is None or client not in channel.clients:
+            return
+        channel.clients.discard(client)
+        client.topics.discard(topic)
+        if not channel.clients:
+            channel.task.cancel()
+            del self._channels[topic]
+            log.info("closed channel %s", topic)
+
+    async def _forward_topic(self, topic: str) -> None:
+        encode = _TOPIC_ENCODERS[topic]
+        queue = self._bus.subscribe(topic)
+        try:
+            while True:
+                payload = await queue.get()
+                try:
+                    frame = json.dumps({"topic": topic, "data": encode(payload)})
+                except Exception:
+                    log.exception("dropping unencodable payload on %s", topic)
+                    continue
+                for client in self._channels[topic].clients:
+                    client.post(frame)
+        finally:
+            self._bus.unsubscribe(topic, queue)


### PR DESCRIPTION
Stacked on #13

The wrapper publishes geometry on an internal bus, but nothing outside the process can see it. A calibration UI needs a way in, and so does any other observer (dashboard, debug client, etc.).

This PR adds `wrapper/websocket.py`, a small `websockets`-based bridge that exposes bus topics as JSON. A UI can simply subscribe to e.g. `geometry.in` over a websocket to get SSL geometry messages as JSON.

The wire protocol is (`{"action", "topic"}` in, `{"topic", "data"}` out) so inbound commands can be added later without breaking existing clients. Read-only for now. `tools/ws_tail.py` is a tiny dev client for tailing a channel from the terminal.